### PR TITLE
Change minimum OpenGL version to 3.0 instead of 3.1

### DIFF
--- a/data/cr/shaders_gl/bones.glslf
+++ b/data/cr/shaders_gl/bones.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec2 fTexUV;
 uniform sampler2D uTex;

--- a/data/cr/shaders_gl/bones.glslv
+++ b/data/cr/shaders_gl/bones.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 const int MAX_BONES = 32;
 

--- a/data/cr/shaders_gl/dissolve.glslf
+++ b/data/cr/shaders_gl/dissolve.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec2 fTexUV;
 uniform sampler2D uTex;

--- a/data/cr/shaders_gl/dissolve.glslv
+++ b/data/cr/shaders_gl/dissolve.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 vPosition;
 in vec3 vNormal;

--- a/data/cr/shaders_gl/entities.glslf
+++ b/data/cr/shaders_gl/entities.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec2 fTexUV;
 uniform sampler2D uTex;

--- a/data/cr/shaders_gl/entities.glslv
+++ b/data/cr/shaders_gl/entities.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 vPosition;
 in vec3 vNormal;

--- a/data/cr/shaders_gl/particles.glslf
+++ b/data/cr/shaders_gl/particles.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 fColor;
 

--- a/data/cr/shaders_gl/particles.glslv
+++ b/data/cr/shaders_gl/particles.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 vPosition;
 in vec3 vColor;

--- a/data/cr/shaders_gl/phong.glslf
+++ b/data/cr/shaders_gl/phong.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec2 fTexUV;
 in vec3 fNormal;

--- a/data/cr/shaders_gl/phong.glslv
+++ b/data/cr/shaders_gl/phong.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 vPosition;
 in vec3 vNormal;

--- a/data/cr/shaders_gl/phong_bump.glslf
+++ b/data/cr/shaders_gl/phong_bump.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec2 fTexUV;
 in vec3 fLightDir[2];

--- a/data/cr/shaders_gl/phong_bump.glslv
+++ b/data/cr/shaders_gl/phong_bump.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 vPosition;
 in vec3 vNormal;
@@ -10,14 +10,14 @@ out vec3 fLightDir[2];
 
 uniform mat4 uMVP;
 uniform mat4 uMV;
-uniform mat3 uN;
+uniform mat3 uN3;
 uniform vec3 uLightPos[2];
 
 
 void main()
 {
-	vec3 n = normalize(uN * vNormal);
-	vec3 t = normalize(uN * vTangent);
+	vec3 n = normalize(uN3 * vNormal);
+	vec3 t = normalize(uN3 * vTangent);
 	vec3 b = cross(n, t);
 	
 	vec4 vertexPos = uMV * vec4(vPosition, 1.0f);

--- a/data/cr/shaders_gl/skybox.glslf
+++ b/data/cr/shaders_gl/skybox.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 fTexUV;
 in float fDepth;

--- a/data/cr/shaders_gl/skybox.glslv
+++ b/data/cr/shaders_gl/skybox.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 vPosition;
 out vec3 fTexUV;

--- a/data/cr/shaders_gl/terrain.glslf
+++ b/data/cr/shaders_gl/terrain.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec2 fTexUV;
 in vec3 fNormal;

--- a/data/cr/shaders_gl/terrain.glslv
+++ b/data/cr/shaders_gl/terrain.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 vPosition;
 in vec3 vNormal;

--- a/data/cr/shaders_gl/text.glslf
+++ b/data/cr/shaders_gl/text.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec2 fTexUV;
 uniform sampler2D uTex;

--- a/data/cr/shaders_gl/text.glslv
+++ b/data/cr/shaders_gl/text.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec4 vCoord;
 out vec2 fTexUV;

--- a/data/cr/shaders_gl/water.glslf
+++ b/data/cr/shaders_gl/water.glslf
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec2 fTexUV;
 uniform sampler2D uTex;

--- a/data/cr/shaders_gl/water.glslv
+++ b/data/cr/shaders_gl/water.glslv
@@ -1,4 +1,4 @@
-#version 140
+#version 130
 
 in vec3 vPosition;
 in vec3 vNormal;

--- a/src/render_opengl/render_opengl.cpp
+++ b/src/render_opengl/render_opengl.cpp
@@ -255,7 +255,7 @@ void RenderOpenGL::setScreenSize(int width, int height, bool fullscreen)
 	
 	// Check compat an init GLEW
 	#ifdef OpenGL
-		if (atof((char*) glGetString(GL_VERSION)) < 3.1) {
+		if (atof((char*) glGetString(GL_VERSION)) < 3.0) {
 			reportFatalError("OpenGL 3.1 or later is required for the high-end renderer, but not supported on this system. Try the low-end one.");
 		}
 		

--- a/src/spark/RenderingAPIs/OpenGL/SPK_GL2PointRenderer.cpp
+++ b/src/spark/RenderingAPIs/OpenGL/SPK_GL2PointRenderer.cpp
@@ -68,7 +68,7 @@ namespace GL
 
 		// Create shader
 		shaderIndex = createShaderProgram(
-			"#version 140\n"
+			"#version 130\n"
 			"in vec3 vPosition;\n"
 			"in vec4 vColor;\n"
 			"out vec4 fColor;\n"
@@ -78,7 +78,7 @@ namespace GL
 				"fColor = vColor;\n"
 			"}\n",
 
-			"#version 140\n"
+			"#version 130\n"
 			"in vec4 fColor;\n"
 			"void main() {\n"
 				"gl_FragColor = fColor;\n"


### PR DESCRIPTION
This broadens the range of cards supported.

Lowered the required OpenGL version from 3.1 to 3.0.
Lowered the required GLSL version from 1.40 to 1.30.

Very little actual code was changed, only the version checks.

Tested on Linux and Windows.
Tested on NVidia official, NVidia open source, AMD (unknown) and Intel integrated.
